### PR TITLE
ci: optimize test workflow to trigger only on Go-related changes

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: 
       - main
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/build-test.yaml'
 
 env:
   CGO_ENABLED: 0


### PR DESCRIPTION
## Summary

Optimizes the build-test workflow to only run when Go-related files change, reducing unnecessary CI runs for documentation and configuration changes.

## Changes

Added `paths` filter to the pull request trigger in `.github/workflows/build-test.yaml`:

- `**.go` - All Go source files
- `go.mod` - Go module definition  
- `go.sum` - Dependency checksums
- `.github/workflows/build-test.yaml` - The workflow file itself

## Benefits

- **Faster feedback**: No waiting for tests when only docs/config change
- **Resource efficiency**: Reduces CI runner usage for non-code changes
- **Better developer experience**: Only relevant checks run for each change type

## Test plan

- [x] Workflow syntax is valid
- [x] Path filters cover all Go-related files
- [x] Includes workflow file itself to catch workflow changes
- [ ] Test with documentation-only PR (should skip tests)
- [ ] Test with Go code changes (should run tests)

## Examples of changes that will NOT trigger tests:
- README.md updates
- CLAUDE.md documentation changes  
- .gitignore modifications
- YAML config files (except the workflow itself)

## Examples of changes that WILL trigger tests:
- Any .go file modifications
- go.mod/go.sum dependency updates
- Changes to the test workflow itself

🤖 Generated with [Claude Code](https://claude.ai/code)